### PR TITLE
Use hosted agents for this test build.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,8 +2,7 @@ trigger:
 - main
 
 pool:
-  name: NetCore1ESPool-Public
-  demands: ImageOverride -equals build.server.amd64.vs2019.open
+  vmImage: windows-latest
 
 jobs:
   - job: FailingTests


### PR DESCRIPTION
The PR build for this repo is run inside a post-deployment test for helix. It is important that this build start promptly, so we need to use the hosted pool. This repo is as far away from our products as you can possibly get, so hosted vs not isn't a problem.