### PR TITLE
correct path to BuildResultAnalysisTests.csproj

### DIFF
--- a/BuildResultAnalysisTest.sln
+++ b/BuildResultAnalysisTest.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.1.31907.60
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BuildResultAnalysisTest", "src\BuildResultAnalysisTest\BuildResultAnalysisTest.csproj", "{7BFF74D5-5898-4A69-9462-A8356D2447D0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BuildResultAnalysisTest", "src\BuildResultAnalysisTests\BuildResultAnalysisTests.csproj", "{7BFF74D5-5898-4A69-9462-A8356D2447D0}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SecondaryTests", "SecondaryTests\SecondaryTests.csproj", "{AFA27321-FE4F-4CFF-BF39-11488BC09B79}"
 EndProject

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,6 @@ jobs:
           script: mkdir $(Build.SourcesDirectory)\myresult123456-fail1 |  echo "Fail" > $(Build.SourcesDirectory)\myresult123456-fail1\my-result-123456.txt
       - template: /eng/common/templates/steps/send-to-helix.yml
         parameters:
-          continueOnError: true
           HelixSource: pr/test/buildresult/$(Build.SourceBranch) # sources must start with pr/, official/, prodcon/, or agent/
           HelixType: type/tests
           HelixTargetQueues: Windows.10.Amd64.Open; # specify appropriate queues here; see https://helix.dot.net/ for a list of queues
@@ -78,7 +77,6 @@ jobs:
           script: mkdir $(Build.SourcesDirectory)\myresult123456-fail2 |  echo "Fail" > $(Build.SourcesDirectory)\myresult123456-fail2\my-result-123456.txt
       - template: /eng/common/templates/steps/send-to-helix.yml
         parameters:
-          continueOnError: true
           HelixSource: pr/test/buildresult/$(Build.SourceBranch) # sources must start with pr/, official/, prodcon/, or agent/
           HelixType: type/tests
           HelixTargetQueues: Windows.10.Amd64.Open; # specify appropriate queues here; see https://helix.dot.net/ for a list of queues

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,12 +32,12 @@ jobs:
           XUnitProjects: $(Build.SourcesDirectory)/src/TestAggregatorHelixTests/TestAggregatorHelixTests.csproj # specify your xUnit projects (semicolon delimited) here!
           XUnitPublishTargetFramework: net8.0 # specify your publish target framework here
           XUnitTargetFramework: net8.0 # specify the framework you want to use for the xUnit runner
-          XUnitRunnerVersion: 2.4.1 # specify the version of xUnit runner you wish to use here
+          XUnitRunnerVersion: 2.9.3 # specify the version of xUnit runner you wish to use here
           IncludeDotNetCli: true
           EnableXUnitReporter: true
           WaitForWorkItemCompletion: true
           DotNetCliPackageType: sdk
-          DotNetCliVersion: 3.1.410 # full list of versions here: https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases.json
+          DotNetCliVersion: 8.0.17 # full list of versions here: https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases.json
           Creator: dotnet-helix-low-bot # specify an appropriate Creator here -- required for external builds
     - task: CmdLine@2
       inputs:
@@ -51,12 +51,12 @@ jobs:
           XUnitProjects: $(Build.SourcesDirectory)/src/TestAggregatorHelixTests/TestAggregatorHelixTests.csproj # specify your xUnit projects (semicolon delimited) here!
           XUnitPublishTargetFramework: net8.0 # specify your publish target framework here
           XUnitTargetFramework: net8.0 # specify the framework you want to use for the xUnit runner
-          XUnitRunnerVersion: 2.4.1 # specify the version of xUnit runner you wish to use here
+          XUnitRunnerVersion: 2.9.3 # specify the version of xUnit runner you wish to use here
           IncludeDotNetCli: true
           EnableXUnitReporter: true
           WaitForWorkItemCompletion: true
           DotNetCliPackageType: sdk
-          DotNetCliVersion: 3.1.410 # full list of versions here: https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases.json
+          DotNetCliVersion: 8.0.17  # full list of versions here: https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases.json
           Creator: dotnet-helix-low-bot # specify an appropriate Creator here -- required for external builds
     - task: CmdLine@2
       inputs:
@@ -70,11 +70,11 @@ jobs:
           XUnitProjects: $(Build.SourcesDirectory)/src/TestAggregatorHelixTests/TestAggregatorHelixTests.csproj # specify your xUnit projects (semicolon delimited) here!
           XUnitPublishTargetFramework: net8.0 # specify your publish target framework here
           XUnitTargetFramework: net8.0 # specify the framework you want to use for the xUnit runner
-          XUnitRunnerVersion: 2.4.1 # specify the version of xUnit runner you wish to use here
+          XUnitRunnerVersion: 2.9.3 # specify the version of xUnit runner you wish to use here
           IncludeDotNetCli: true
           EnableXUnitReporter: true
           WaitForWorkItemCompletion: true
           DotNetCliPackageType: sdk
           HelixBaseUri: 'https://helix.dot.net/'
-          DotNetCliVersion: 3.1.410 # full list of versions here: https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases.json
+          DotNetCliVersion: 8.0.17  # full list of versions here: https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases.json
           Creator: dotnet-helix-low-bot # specify an appropriate Creator here -- required for external builds

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ jobs:
           EnableXUnitReporter: true
           WaitForWorkItemCompletion: true
           DotNetCliPackageType: sdk
-          DotNetCliVersion: 8.0.17 # full list of versions here: https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases.json
+          DotNetCliVersion: 8.0.411 # full list of versions here: https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases.json
           Creator: dotnet-helix-low-bot # specify an appropriate Creator here -- required for external builds
     - task: CmdLine@2
       inputs:
@@ -56,7 +56,7 @@ jobs:
           EnableXUnitReporter: true
           WaitForWorkItemCompletion: true
           DotNetCliPackageType: sdk
-          DotNetCliVersion: 8.0.17  # full list of versions here: https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases.json
+          DotNetCliVersion: 8.0.411 # full list of versions here: https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases.json
           Creator: dotnet-helix-low-bot # specify an appropriate Creator here -- required for external builds
     - task: CmdLine@2
       inputs:
@@ -76,5 +76,5 @@ jobs:
           WaitForWorkItemCompletion: true
           DotNetCliPackageType: sdk
           HelixBaseUri: 'https://helix.dot.net/'
-          DotNetCliVersion: 8.0.17  # full list of versions here: https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases.json
+          DotNetCliVersion: 8.0.411  # full list of versions here: https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases.json
           Creator: dotnet-helix-low-bot # specify an appropriate Creator here -- required for external builds

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,10 +8,12 @@ jobs:
   - job: FailingTests
     steps:
     - task: DotNetCoreCLI@2
+      displayName: 'Build Test Projects'
       inputs:
         command: 'build'
         projects: '**\*Tests.csproj'
     - task: VSTest@2
+      displayName: 'Run BuildResultAnalysisTests'
       inputs:
         testSelector: 'testAssemblies'
         testAssemblyVer2: |
@@ -21,6 +23,7 @@ jobs:
   - job: HelixTests
     steps:
     - task: CmdLine@2
+      displayName: 'Create Pass Result File'
       inputs:
         script: mkdir $(Build.SourcesDirectory)\myresult123456 |  echo "Pass" > $(Build.SourcesDirectory)\myresult123456\my-result-123456.txt
     - template: /eng/common/templates/steps/send-to-helix.yml
@@ -40,11 +43,12 @@ jobs:
           DotNetCliVersion: 8.0.411 # full list of versions here: https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases.json
           Creator: dotnet-helix-low-bot # specify an appropriate Creator here -- required for external builds
     - task: CmdLine@2
+      displayName: 'Create Fail Result File 1'
       inputs:
         script: mkdir $(Build.SourcesDirectory)\myresult123456 |  echo "Fail" > $(Build.SourcesDirectory)\myresult123456\my-result-123456.txt
     - template: /eng/common/templates/steps/send-to-helix.yml
-      continueOnError: true
       parameters:
+          continueOnError: true
           HelixSource: pr/test/buildresult/$(Build.SourceBranch) # sources must start with pr/, official/, prodcon/, or agent/
           HelixType: type/tests
           HelixTargetQueues: Windows.10.Amd64.Open; # specify appropriate queues here; see https://helix.dot.net/ for a list of queues
@@ -60,11 +64,12 @@ jobs:
           DotNetCliVersion: 8.0.411 # full list of versions here: https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases.json
           Creator: dotnet-helix-low-bot # specify an appropriate Creator here -- required for external builds
     - task: CmdLine@2
+      displayName: 'Create Fail Result File 2'
       inputs:
         script: mkdir $(Build.SourcesDirectory)\myresult123456 |  echo "Fail" > $(Build.SourcesDirectory)\myresult123456\my-result-123456.txt
     - template: /eng/common/templates/steps/send-to-helix.yml
-      continueOnError: true
       parameters:
+          continueOnError: true
           HelixSource: pr/test/buildresult/$(Build.SourceBranch) # sources must start with pr/, official/, prodcon/, or agent/
           HelixType: type/tests
           HelixTargetQueues: Windows.10.Amd64.Open; # specify appropriate queues here; see https://helix.dot.net/ for a list of queues

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ jobs:
           XUnitProjects: $(Build.SourcesDirectory)/src/TestAggregatorHelixTests/TestAggregatorHelixTests.csproj # specify your xUnit projects (semicolon delimited) here!
           XUnitPublishTargetFramework: net8.0 # specify your publish target framework here
           XUnitTargetFramework: net8.0 # specify the framework you want to use for the xUnit runner
-          XUnitRunnerVersion: 2.9.3 # specify the version of xUnit runner you wish to use here
+          XUnitRunnerVersion: 2.4.2 # specify the version of xUnit runner you wish to use here
           IncludeDotNetCli: true
           EnableXUnitReporter: true
           WaitForWorkItemCompletion: true
@@ -51,7 +51,7 @@ jobs:
           XUnitProjects: $(Build.SourcesDirectory)/src/TestAggregatorHelixTests/TestAggregatorHelixTests.csproj # specify your xUnit projects (semicolon delimited) here!
           XUnitPublishTargetFramework: net8.0 # specify your publish target framework here
           XUnitTargetFramework: net8.0 # specify the framework you want to use for the xUnit runner
-          XUnitRunnerVersion: 2.9.3 # specify the version of xUnit runner you wish to use here
+          XUnitRunnerVersion: 2.4.2 # specify the version of xUnit runner you wish to use here
           IncludeDotNetCli: true
           EnableXUnitReporter: true
           WaitForWorkItemCompletion: true
@@ -70,7 +70,7 @@ jobs:
           XUnitProjects: $(Build.SourcesDirectory)/src/TestAggregatorHelixTests/TestAggregatorHelixTests.csproj # specify your xUnit projects (semicolon delimited) here!
           XUnitPublishTargetFramework: net8.0 # specify your publish target framework here
           XUnitTargetFramework: net8.0 # specify the framework you want to use for the xUnit runner
-          XUnitRunnerVersion: 2.9.3 # specify the version of xUnit runner you wish to use here
+          XUnitRunnerVersion: 2.4.2 # specify the version of xUnit runner you wish to use here
           IncludeDotNetCli: true
           EnableXUnitReporter: true
           WaitForWorkItemCompletion: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,8 @@ pool:
   vmImage: windows-latest
 
 jobs:
-  - job: FailingTests
+  - job: SuccessfulTest
+    timeoutInMinutes: 120
     steps:
     - task: DotNetCoreCLI@2
       displayName: 'Build Test Projects'
@@ -25,13 +26,13 @@ jobs:
     - task: CmdLine@2
       displayName: 'Create Pass Result File'
       inputs:
-        script: mkdir $(Build.SourcesDirectory)\myresult123456 |  echo "Pass" > $(Build.SourcesDirectory)\myresult123456\my-result-123456.txt
+        script: mkdir $(Build.SourcesDirectory)\myresult123456-ok |  echo "Pass" > $(Build.SourcesDirectory)\myresult123456-ok\my-result-123456.txt
     - template: /eng/common/templates/steps/send-to-helix.yml
       parameters:
           HelixSource: pr/test/buildresult/$(Build.SourceBranch) # sources must start with pr/, official/, prodcon/, or agent/
           HelixType: type/tests
           HelixTargetQueues: Windows.10.Amd64.Open; # specify appropriate queues here; see https://helix.dot.net/ for a list of queues
-          CorrelationPayloadDirectory: $(Build.SourcesDirectory)/myresult123456
+          CorrelationPayloadDirectory: $(Build.SourcesDirectory)/myresult123456-ok
           XUnitProjects: $(Build.SourcesDirectory)/src/TestAggregatorHelixTests/TestAggregatorHelixTests.csproj # specify your xUnit projects (semicolon delimited) here!
           XUnitPublishTargetFramework: net8.0 # specify your publish target framework here
           XUnitTargetFramework: net8.0 # specify the framework you want to use for the xUnit runner
@@ -42,17 +43,21 @@ jobs:
           DotNetCliPackageType: sdk
           DotNetCliVersion: 8.0.411 # full list of versions here: https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases.json
           Creator: dotnet-helix-low-bot # specify an appropriate Creator here -- required for external builds
-    - task: CmdLine@2
-      displayName: 'Create Fail Result File 1'
-      inputs:
-        script: mkdir $(Build.SourcesDirectory)\myresult123456 |  echo "Fail" > $(Build.SourcesDirectory)\myresult123456\my-result-123456.txt
-    - template: /eng/common/templates/steps/send-to-helix.yml
-      parameters:
+  - job: HelixTest1
+    displayName: 'Helix failed Test 1'
+    timeoutInMinutes: 120
+    steps:
+      - task: CmdLine@2
+        displayName: 'Create Fail Result File 1'
+        inputs:
+          script: mkdir $(Build.SourcesDirectory)\myresult123456-fail1 |  echo "Fail" > $(Build.SourcesDirectory)\myresult123456-fail1\my-result-123456.txt
+      - template: /eng/common/templates/steps/send-to-helix.yml
+        parameters:
           continueOnError: true
           HelixSource: pr/test/buildresult/$(Build.SourceBranch) # sources must start with pr/, official/, prodcon/, or agent/
           HelixType: type/tests
           HelixTargetQueues: Windows.10.Amd64.Open; # specify appropriate queues here; see https://helix.dot.net/ for a list of queues
-          CorrelationPayloadDirectory: $(Build.SourcesDirectory)/myresult123456
+          CorrelationPayloadDirectory: $(Build.SourcesDirectory)/myresult123456-fail1
           XUnitProjects: $(Build.SourcesDirectory)/src/TestAggregatorHelixTests/TestAggregatorHelixTests.csproj # specify your xUnit projects (semicolon delimited) here!
           XUnitPublishTargetFramework: net8.0 # specify your publish target framework here
           XUnitTargetFramework: net8.0 # specify the framework you want to use for the xUnit runner
@@ -63,17 +68,21 @@ jobs:
           DotNetCliPackageType: sdk
           DotNetCliVersion: 8.0.411 # full list of versions here: https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases.json
           Creator: dotnet-helix-low-bot # specify an appropriate Creator here -- required for external builds
-    - task: CmdLine@2
-      displayName: 'Create Fail Result File 2'
-      inputs:
-        script: mkdir $(Build.SourcesDirectory)\myresult123456 |  echo "Fail" > $(Build.SourcesDirectory)\myresult123456\my-result-123456.txt
-    - template: /eng/common/templates/steps/send-to-helix.yml
-      parameters:
+  - job: HelixTest2
+    displayName: 'Helix failed Test 2'
+    timeoutInMinutes: 120
+    steps:
+      - task: CmdLine@2
+        displayName: 'Create Fail Result File 2'
+        inputs:
+          script: mkdir $(Build.SourcesDirectory)\myresult123456-fail2 |  echo "Fail" > $(Build.SourcesDirectory)\myresult123456-fail2\my-result-123456.txt
+      - template: /eng/common/templates/steps/send-to-helix.yml
+        parameters:
           continueOnError: true
           HelixSource: pr/test/buildresult/$(Build.SourceBranch) # sources must start with pr/, official/, prodcon/, or agent/
           HelixType: type/tests
           HelixTargetQueues: Windows.10.Amd64.Open; # specify appropriate queues here; see https://helix.dot.net/ for a list of queues
-          CorrelationPayloadDirectory: $(Build.SourcesDirectory)/myresult123456
+          CorrelationPayloadDirectory: $(Build.SourcesDirectory)/myresult123456-fail2
           XUnitProjects: $(Build.SourcesDirectory)/src/TestAggregatorHelixTests/TestAggregatorHelixTests.csproj # specify your xUnit projects (semicolon delimited) here!
           XUnitPublishTargetFramework: net8.0 # specify your publish target framework here
           XUnitTargetFramework: net8.0 # specify the framework you want to use for the xUnit runner
@@ -82,6 +91,5 @@ jobs:
           EnableXUnitReporter: true
           WaitForWorkItemCompletion: true
           DotNetCliPackageType: sdk
-          HelixBaseUri: 'https://helix.dot.net/'
-          DotNetCliVersion: 8.0.411  # full list of versions here: https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases.json
+          DotNetCliVersion: 8.0.411 # full list of versions here: https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases.json
           Creator: dotnet-helix-low-bot # specify an appropriate Creator here -- required for external builds

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ jobs:
       inputs:
         testSelector: 'testAssemblies'
         testAssemblyVer2: |
-            **\BuildResultAnalysisTest.dll
+            **\BuildResultAnalysisTests.dll
             !**\obj\**
         searchFolder: '$(System.DefaultWorkingDirectory)'
   - job: HelixTests
@@ -40,6 +40,7 @@ jobs:
           DotNetCliVersion: 8.0.411 # full list of versions here: https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases.json
           Creator: dotnet-helix-low-bot # specify an appropriate Creator here -- required for external builds
     - task: CmdLine@2
+      continueOnError: true
       inputs:
         script: mkdir $(Build.SourcesDirectory)\myresult123456 |  echo "Fail" > $(Build.SourcesDirectory)\myresult123456\my-result-123456.txt
     - template: /eng/common/templates/steps/send-to-helix.yml
@@ -59,6 +60,7 @@ jobs:
           DotNetCliVersion: 8.0.411 # full list of versions here: https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases.json
           Creator: dotnet-helix-low-bot # specify an appropriate Creator here -- required for external builds
     - task: CmdLine@2
+      continueOnError: true
       inputs:
         script: mkdir $(Build.SourcesDirectory)\myresult123456 |  echo "Fail" > $(Build.SourcesDirectory)\myresult123456\my-result-123456.txt
     - template: /eng/common/templates/steps/send-to-helix.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,10 +40,10 @@ jobs:
           DotNetCliVersion: 8.0.411 # full list of versions here: https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases.json
           Creator: dotnet-helix-low-bot # specify an appropriate Creator here -- required for external builds
     - task: CmdLine@2
-      continueOnError: true
       inputs:
         script: mkdir $(Build.SourcesDirectory)\myresult123456 |  echo "Fail" > $(Build.SourcesDirectory)\myresult123456\my-result-123456.txt
     - template: /eng/common/templates/steps/send-to-helix.yml
+      continueOnError: true
       parameters:
           HelixSource: pr/test/buildresult/$(Build.SourceBranch) # sources must start with pr/, official/, prodcon/, or agent/
           HelixType: type/tests
@@ -60,10 +60,10 @@ jobs:
           DotNetCliVersion: 8.0.411 # full list of versions here: https://raw.githubusercontent.com/dotnet/core/main/release-notes/releases.json
           Creator: dotnet-helix-low-bot # specify an appropriate Creator here -- required for external builds
     - task: CmdLine@2
-      continueOnError: true
       inputs:
         script: mkdir $(Build.SourcesDirectory)\myresult123456 |  echo "Fail" > $(Build.SourcesDirectory)\myresult123456\my-result-123456.txt
     - template: /eng/common/templates/steps/send-to-helix.yml
+      continueOnError: true
       parameters:
           HelixSource: pr/test/buildresult/$(Build.SourceBranch) # sources must start with pr/, official/, prodcon/, or agent/
           HelixType: type/tests

--- a/global.json
+++ b/global.json
@@ -1,15 +1,11 @@
 {
-  "tools": {
-    "dotnet": "10.0.100-preview.6.25302.104",
-    "runtimes": {
-      "dotnet": [
-        "3.1.16"
-      ]
-    }
+  "sdk": {
+    "version": "10.0.100-preview.3.25201.16",
+    "allowPrerelease": true,
+    "rollForward": "major"
   },
-  "native-tools": {
-    "cmake": "3.11.1",
-    "cmake-test": "3.11.1"
+  "tools": {
+    "dotnet": "10.0.100-preview.6.25302.104"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25316.2",

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "10.0.100-preview.3.25201.16",
+    "version": "8.0.411",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "10.0.100-preview.6.25302.104"
+    "dotnet": "8.0.411"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25316.2",

--- a/global.json
+++ b/global.json
@@ -8,7 +8,7 @@
     "dotnet": "8.0.411"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25316.2",
-    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25316.2"
+    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.25263.4",
+    "Microsoft.DotNet.Helix.Sdk": "8.0.0-beta.25263.4"
   }
 }

--- a/src/BuildResultAnalysisTests/BuildResultAnalysisTests.csproj
+++ b/src/BuildResultAnalysisTests/BuildResultAnalysisTests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>false</IsPackable>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/TestAggregatorHelixTests/TestAggregatorHelixTests.csproj
+++ b/src/TestAggregatorHelixTests/TestAggregatorHelixTests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>false</IsPackable>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change has four parts.
- fix tests failing like 
```
C:\h\w\A6DA08F1\w\B6DB0A24\e>dotnet exec --roll-forward Major --runtimeconfig TestAggregatorHelixTests.runtimeconfig.json --depsfile TestAggregatorHelixTests.deps.json C:\h\w\A6DA08F1\p/xunit-runner/tools/netcoreapp2.0/xunit.console.dll TestAggregatorHelixTests.dll -nocolor -xml testResults.xml  
The specified runtimeconfig.json [TestAggregatorHelixTests.runtimeconfig.json] does not exist
```

this seems to be caused by .NET upgrade and its behavior SDK change
- actually fixes the paths locations. It seems like we use singular instead of plural in sever places and that was causing pipeline warnings and "dotnet build" does not work from top directory. 

- it also updates some package and dotnet versions. 3.1 is no longer needed and I sync everything up with runtime 8.0 branch. (to avoid begging on 10.x bleeding edge) 

- it can take a while to get Helix run our jobs. The old one would run every in sequence so when wait Tims is 20-30 minutes it can take long time. Since the tests are independent I split them to 3 Jons so they can execute in parallel.  