### PR TITLE
[BuildInsights Repro] Replay #6179: [main] Update dependencies from dotnet/dnceng-shared

### DIFF
--- a/pr.md
+++ b/pr.md
@@ -1,0 +1,9 @@
+# Build Insights repro
+
+Original PR: https://github.com/dotnet/arcade-services/pull/6179
+Original title: [main] Update dependencies from dotnet/dnceng-shared
+Original head SHA: 73d3361885950b2ea823f9d7c572c6fd2b9a745a
+Replayed at: 2026-04-16T12:55:53.2528651+00:00
+
+Builds:
+- dotnet-arcade-services: dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649 build 1378194


### PR DESCRIPTION
## Build Insights repro

- Original PR: https://github.com/dotnet/arcade-services/pull/6179
- Original head SHA: 73d3361885950b2ea823f9d7c572c6fd2b9a745a
- Replay requested at: 2026-04-16T12:56:01.1449704+00:00
- Builds to replay: 1

This PR was created by BuildInsights.ReproTool to replay existing Azure DevOps build completion events against a local Build Insights instance.