### PR TITLE
[BuildInsights Repro] Replay #6194: Automatically open reset PRs after codeflow source branch changes

### DIFF
--- a/pr.md
+++ b/pr.md
@@ -1,0 +1,9 @@
+# Build Insights repro
+
+Original PR: https://github.com/dotnet/arcade-services/pull/6194
+Original title: Automatically open reset PRs after codeflow source branch changes
+Original head SHA: 9798e57b8b5df69fac6f80755efd7146a59b7582
+Replayed at: 2026-04-17T15:32:56.6918380+00:00
+
+Builds:
+- dotnet-arcade-services: dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649 build 1383986


### PR DESCRIPTION
## Build Insights repro

- Original PR: https://github.com/dotnet/arcade-services/pull/6194
- Original head SHA: 9798e57b8b5df69fac6f80755efd7146a59b7582
- Replay requested at: 2026-04-17T15:32:57.8293373+00:00
- Builds to replay: 1

This PR was created by BuildInsights.ReproTool to replay existing Azure DevOps build completion events against a local Build Insights instance.