### PR TITLE
[BuildInsights Repro] Replay #129312: JIT: forward-sub cheap address temps with multiple uses

### DIFF
--- a/pr.md
+++ b/pr.md
@@ -1,0 +1,13 @@
+# Build Insights repro
+
+Original PR: https://github.com/dotnet/runtime/pull/129312
+Original title: JIT: forward-sub cheap address temps with multiple uses
+Original head SHA: b1a0c81be5c1776b446ac75814bf226dfb8aa89e
+Replayed at: 2026-06-12T14:06:06.6043859+00:00
+
+Builds:
+- runtime: dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649 build 1460644
+- runtime-coreclr superpmi-diffs: dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649 build 1460647
+- runtime-coreclr hardware-intrinsics: dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649 build 1460648
+- dotnet-linker-tests: dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649 build 1460646
+- runtime-dev-innerloop: dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649 build 1460645


### PR DESCRIPTION
## Build Insights repro

- Original PR: https://github.com/dotnet/runtime/pull/129312
- Original head SHA: b1a0c81be5c1776b446ac75814bf226dfb8aa89e
- Replay requested at: 2026-06-12T14:06:07.7879117+00:00
- Builds to replay: 5

This PR was created by BuildInsights.ReproTool to replay existing Azure DevOps build completion events against a local Build Insights instance.