### PR TITLE
[BuildInsights Repro] Replay #129312: JIT: forward-sub cheap address temps with multiple uses

### DIFF
--- a/pr.md
+++ b/pr.md
@@ -1,0 +1,13 @@
+# Build Insights repro
+
+Original PR: https://github.com/dotnet/runtime/pull/129312
+Original title: JIT: forward-sub cheap address temps with multiple uses
+Original head SHA: 71a0a06625572fe57f790957b9d5b294506f111c
+Replayed at: 2026-06-12T15:42:03.3435334+00:00
+
+Builds:
+- runtime (Build maccatalyst-arm64 Release AllSubsets_CoreCLR_Smoke): dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649 build 1461696
+- dotnet-linker-tests (Build windows-x64 release Runtime_Release): dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649 build 1461698
+- runtime-dev-innerloop (Build Source-Build (Linux_x64)): dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649 build 1461697
+- runtime-coreclr superpmi-diffs (Build windows-x86 release): dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649 build 1461699
+- runtime-coreclr hardware-intrinsics (Build linux-x64 Release NativeAOT): dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649 build 1461700


### PR DESCRIPTION
## Build Insights repro

- Original PR: https://github.com/dotnet/runtime/pull/129312
- Original head SHA: 71a0a06625572fe57f790957b9d5b294506f111c
- Replay requested at: 2026-06-12T15:42:04.3529841+00:00
- Builds to replay: 5

This PR was created by BuildInsights.ReproTool to replay existing Azure DevOps build completion events against a local Build Insights instance.