### PR TITLE
[BuildInsights Repro] Replay #128585: [ci-scan] Skip ExpressionDebuggerTypeProxyTests.ThrowOnNullToCtor on Android

### DIFF
--- a/pr.md
+++ b/pr.md
@@ -1,0 +1,11 @@
+# Build Insights repro
+
+Original PR: https://github.com/dotnet/runtime/pull/128585
+Original title: [ci-scan] Skip ExpressionDebuggerTypeProxyTests.ThrowOnNullToCtor on Android
+Original head SHA: 31b994669636b86cd0d2bb43e5082ed0bd5c8a57
+Replayed at: 2026-06-16T15:30:14.9320924+00:00
+
+Builds:
+- runtime: dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649 build 1466161
+- dotnet-linker-tests: dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649 build 1466163
+- runtime-dev-innerloop: dnceng-public/cbb18261-c48f-4abb-8651-8cdcb5474649 build 1466162


### PR DESCRIPTION
## Build Insights repro

- Original PR: https://github.com/dotnet/runtime/pull/128585
- Original head SHA: 31b994669636b86cd0d2bb43e5082ed0bd5c8a57
- Replay requested at: 2026-06-16T15:30:16.0860131+00:00
- Builds to replay: 3

This PR was created by BuildInsights.ReproTool to replay existing Azure DevOps build completion events against a local Build Insights instance.